### PR TITLE
[FootStepGenerator] fix remainTime threshold for goNextFootStepNodesList

### DIFF
--- a/auto_stabilizer/rtc/AutoStabilizer/FootStepGenerator.cpp
+++ b/auto_stabilizer/rtc/AutoStabilizer/FootStepGenerator.cpp
@@ -243,7 +243,7 @@ bool FootStepGenerator::procFootStepNodesList(const GaitParam& gaitParam, const 
   elapsedTime += dt;
   for(int i=0;i<NUM_LEGS;i++) prevSupportPhase[i] = footstepNodesList[0].isSupportPhase[i];
 
-  if(footstepNodesList[0].remainTime <= 0.0 && footstepNodesList.size() > 1){ // 次のfootstepNodesListのindexに移る.
+  if(footstepNodesList[0].remainTime <= 1e-10 && footstepNodesList.size() > 1){ // 次のfootstepNodesListのindexに移る. 数値誤差に対応するための微小時間
     if(this->isModifyFootSteps && this->isStableGoStopMode && useActState){
       // footstepNodesList[0]で着地位置修正を行っていたら、footstepNodesListがemergencyStepNumのサイズになるまで歩くnodeが末尾に入る.
       this->checkStableGoStop(footstepNodesList, gaitParam);


### PR DESCRIPTION
auto_stabilizerでdefault_step_timeを長い時間(4秒)にすると、最後の両足支持期に遷移する際に上半身がyaw方向に急激に動く、というバグがありました。

この原因は、

1. 毎周期remainTimeからdtを引く際に数値誤差が蓄積し、
2. 本来remainTimeが0になって次のFootstepNodeに遷移するべき時(https://github.com/Naoki-Hiraoka/auto_stabilizer/blob/master/auto_stabilizer/rtc/AutoStabilizer/FootStepGenerator.cpp#L241-L246 )にremainTimeが極小時間残って遷移せず、
3. その極小時間でfootMidCoordsを補間しようとする(https://github.com/Naoki-Hiraoka/auto_stabilizer/blob/master/auto_stabilizer/rtc/AutoStabilizer/RefToGenFrameConverter.cpp#L117 )ため、補間器がオーバーフローして大きな角加速度を生じ、
4. footMidCoordsのyaw姿勢が乱れてrefRobotのconvert時に姿勢が変わりルートリンク目標姿勢等が急激に変わってしまう

ためでした。

次のFootstepNodeへの遷移判定を修正し、数値誤差に対応するようにしました。

この変更によりdefault_step_timeを長い時間にしても姿勢が急激に変化しないことを確認しました。